### PR TITLE
Added "enumXFF" tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3883,6 +3883,7 @@ User-Agent: Mozilla/4.0 (compatible; MSIE5.01; Windows NT)
 - [abuse-ssl-bypass-waf](https://github.com/LandGrey/abuse-ssl-bypass-waf) - A tool which finds out supported SSL/TLS ciphers and helps in evading WAFs.
 - [SQLMap Tamper Scripts](https://github.com/sqlmapproject/sqlmap) - Tamper scripts in SQLMap obfuscate payloads which might evade some WAFs.
 - [Bypass WAF BurpSuite Plugin](https://portswigger.net/bappstore/ae2611da3bbc4687953a1f4ba6a4e04c) - A plugin for Burp Suite which adds some request headers so that the requests seem from the internal network.
+- [enumXFF](https://github.com/infosec-au/enumXFF) - Eumerating IPs in X-Forwarded-Headers to bypass 403 restrictions
 
 ## Blogs and Writeups
 > Many of the content mentioned above have been taken from some of the following excellent writeups.


### PR DESCRIPTION
enumXFF is a tool for brute-forcing IP ranges in the X-Forwarded-For header. Useful for trying to bypass a WAF configured to only allow certain IPs to access a specific resource.

The tool was featured in [this blogpost](https://shubs.io/enumerating-ips-in-x-forwarded-headers-to-bypass-403-restrictions/) by Shubham Shah